### PR TITLE
Parsing git urls that use `git@...` and `https:git@` format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4"
+branches:
+  only:
+    - master
+script:
+  - npm test

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Supports:
 - `git://` and `.git` w/ `#commit` or `@version`
 - All 5 different ways you could download a freaking tarball/zipball
 
+[![Build status][ci-image] ][ci-url]
+
 ## API
 
 ### [user, repo, version] = parse(url)
@@ -19,3 +21,6 @@ parse('component/emitter#1') // => ['component', 'emitter', '1']
 ```
 
 See the tests for all the different types of supported URLs.
+
+[ci-image]: https://travis-ci.org/bahmutov/parse-github-repo-url.png?branch=master
+[ci-url]: https://travis-ci.org/bahmutov/parse-github-repo-url

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Supports:
 - `<user>/<repo#<commit>`
 - `git://` and `.git` w/ `#commit` or `@version`
 - `git@` and `https:git@`
+- `www.github.com`
 - All 5 different ways you could download a freaking tarball/zipball
 
 [![Build status][ci-image] ][ci-url]

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ parse('component/emitter#1') // => ['component', 'emitter', '1']
 
 See the tests for all the different types of supported URLs.
 
-[ci-image]: https://travis-ci.org/bahmutov/parse-github-repo-url.png?branch=master
-[ci-url]: https://travis-ci.org/bahmutov/parse-github-repo-url
+[ci-image]: https://travis-ci.org/repo-utils/parse-github-repo-url.png?branch=master
+[ci-url]: https://travis-ci.org/repo-utils/parse-github-repo-url

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Supports:
 
 - `<user>/<repo#<commit>`
 - `git://` and `.git` w/ `#commit` or `@version`
+- `git@` and `https:git@`
 - All 5 different ways you could download a freaking tarball/zipball
 
 [![Build status][ci-image] ][ci-url]

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = function (string) {
   var m = /^([\w-]+)\/([\w-.]+)((?:#|@).+)?$/.exec(string)
   if (m) return format(m)
 
+  string = string.replace('//www.', '//')
   // normalize git@ and https:git@ urls
   string = string.replace(/^git@/, 'https://')
   string = string.replace(/^https:git@/, 'https://')

--- a/index.js
+++ b/index.js
@@ -6,7 +6,14 @@ module.exports = function (string) {
   var m = /^([\w-]+)\/([\w-.]+)((?:#|@).+)?$/.exec(string)
   if (m) return format(m)
 
-  if (!~string.indexOf('://')) return false
+  // normalize git@ and https:git@ urls
+  string = string.replace(/^git@/, 'https://')
+  string = string.replace(/^https:git@/, 'https://')
+  string = string.replace('.com:', '.com/')
+
+  if (!~string.indexOf('://')) {
+    return false
+  }
   var url = parse(string)
 
   switch (url.hostname) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parse-github-repo-url",
   "description": "Parse a GitHub URL for user/project@version",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Jonathan Ong",
     "email": "me@jongleberry.com",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "mocha": "1"
   },
+  "main": "index.js",
   "scripts": {
     "test": "mocha --reporter spec --bail"
   }

--- a/test.js
+++ b/test.js
@@ -37,3 +37,33 @@ describe('versioned', function () {
     })
   })
 })
+
+describe('url parse', function () {
+  var builtinUrlParse = require('url').parse
+
+  it('handles https:// url', function () {
+    var url = 'https://foo.com/bar'
+    var parsed = builtinUrlParse(url)
+    assert.equal('foo.com', parsed.hostname)
+  })
+
+  it('does not handle emails', function () {
+    var url = 'git@foo.com/bar'
+    var parsed = builtinUrlParse(url)
+    assert.equal(null, parsed.hostname, JSON.stringify(parsed))
+  })
+})
+
+describe('git @ syntax', function () {
+  it('works for git url', function () {
+    var url = 'git@github.com:bahmutov/lazy-ass.git'
+    var parsed = parse(url)
+    assert.deepEqual(['bahmutov', 'lazy-ass', ''], parsed)
+  });
+
+  it('works for https:git url', function () {
+    var url = 'https:git@github.com:bahmutov/lazy-ass.git'
+    var parsed = parse(url)
+    assert.deepEqual(['bahmutov', 'lazy-ass', ''], parsed)
+  });
+})

--- a/test.js
+++ b/test.js
@@ -17,6 +17,18 @@ describe('versionless', function () {
       assert.deepEqual(['component', 'emitter', ''], parse(url))
     })
   })
+
+  it('works for www.github.com', function () {
+    var url = 'https://www.github.com/component/emitter'
+    var parsed = parse(url)
+    assert.deepEqual(['component', 'emitter', ''], parsed)
+  })
+
+  it('works for http://www.github.com', function () {
+    var url = 'http://www.github.com/component/emitter'
+    var parsed = parse(url)
+    assert.deepEqual(['component', 'emitter', ''], parsed)
+  })
 })
 
 describe('versioned', function () {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 
 var assert = require('assert')
 
-var parse = require('.')
+var parse = require('./')
 
 describe('versionless', function () {
   [


### PR DESCRIPTION
To fix breaking cases when the repo is in the form like this one

```
"repository": {
      "type": "git",
      "url": "git@github.com:bahmutov/lazy-ass.git"
}
```

which affects cool tools like https://github.com/semantic-release/semantic-release/issues/114
