### PR TITLE
Add support for GitLab dotted user

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var parse = require('url').parse
 
 module.exports = function (string) {
   // user/repo#version
-  var m = /^([\w-]+)\/([\w-.]+)((?:#|@).+)?$/.exec(string)
+  var m = /^([\w-.]+)\/([\w-.]+)((?:#|@).+)?$/.exec(string)
   if (m) return format(m)
 
   string = string.replace('//www.', '//')
@@ -19,17 +19,17 @@ module.exports = function (string) {
   var path = url.pathname.replace(/\.git$/, '')
 
   // https://www.npmjs.org/doc/json.html#Git-URLs-as-Dependencies
-  var m = /^\/([\w-]+)\/([\w-.]+)$/.exec(path)
+  var m = /^\/([\w-.]+)\/([\w-.]+)$/.exec(path)
   if (m) return m.slice(1, 3).concat((url.hash || '').slice(1))
 
   // archive link
   // https://developer.github.com/v3/repos/contents/#get-archive-link
-  var m = /^\/repos\/([\w-]+)\/([\w-.]+)\/(?:tarball|zipball)(\/.+)?$/.exec(path)
+  var m = /^\/repos\/([\w-.]+)\/([\w-.]+)\/(?:tarball|zipball)(\/.+)?$/.exec(path)
   if (m) return format(m)
 
   // codeload link
   // https://developer.github.com/v3/repos/contents/#response-4
-  var m = /^\/([\w-]+)\/([\w-.]+)\/(?:legacy\.(?:zip|tar\.gz))(\/.+)?$/.exec(path)
+  var m = /^\/([\w-.]+)\/([\w-.]+)\/(?:legacy\.(?:zip|tar\.gz))(\/.+)?$/.exec(path)
   if (m) return format(m)
 
   // tarball link

--- a/test.js
+++ b/test.js
@@ -52,13 +52,13 @@ describe('versioned', function () {
 
 describe('dotted user', function () {
   [
-    'my.component/my.emitter',
-    'https://github.com/my.component/my.emitter',
-    'https://github.com/repos/my.component/my.emitter/tarball',
-    'https://codeload.github.com/my.component/my.emitter/legacy.zip',
+    'my.component/emitter',
+    'https://github.com/my.component/emitter',
+    'https://github.com/repos/my.component/emitter/tarball',
+    'https://codeload.github.com/my.component/emitter/legacy.zip',
   ].forEach(function (url) {
     it(url, function () {
-      assert.deepEqual(['my.component', 'my.emitter', ''], parse(url))
+      assert.deepEqual(['my.component', 'emitter', ''], parse(url))
     })
   })
 })

--- a/test.js
+++ b/test.js
@@ -50,6 +50,19 @@ describe('versioned', function () {
   })
 })
 
+describe('dotted user', function () {
+  [
+    'my.component/my.emitter',
+    'https://github.com/my.component/my.emitter',
+    'https://github.com/repos/my.component/my.emitter/tarball',
+    'https://codeload.github.com/my.component/my.emitter/legacy.zip',
+  ].forEach(function (url) {
+    it(url, function () {
+      assert.deepEqual(['my.component', 'my.emitter', ''], parse(url))
+    })
+  })
+})
+
 describe('url parse', function () {
   var builtinUrlParse = require('url').parse
 


### PR DESCRIPTION
As GitLab allow dots in user names, i changed the regexps to allow that.

I allow them even for GitHub, to simplify the regexps.

Should close stevemao/get-pkg-repo#9 