### PR TITLE
Support non-gitlab.com repos with subgroups

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,15 @@ module.exports = function (string) {
     }
   }
 
+  // https://docs.gitlab.com/ce/user/group/subgroups/ (not hosted on gitlab.com)
+  var m = /^\/((?:[\w-.]+\/)+)([\w-.]+)$/.exec(path);
+  if (m) {
+    m = m.slice(1, 3);
+    // remove slash at the end
+    m[0] = m[0].slice(0, -1);
+    return m.concat((url.hash || "").slice(1));
+  }
+  
   return false
 }
 

--- a/test.js
+++ b/test.js
@@ -144,3 +144,11 @@ describe('github enterprise urls', function () {
     assert.deepEqual(['user', 'test1', ''], parsed)
   })
 })
+
+describe("github enterprise urls with nested namespace", function() {
+  it("parses https github enterprise url", function() {
+    var url = "https://git.mycompany.com/user/test/test1.git";
+    var parsed = parse(url);
+    assert.deepEqual(["user/test", "test1", ""], parsed);
+  });
+});


### PR DESCRIPTION
I added an additional check at the end of the if block as a catch-all that will handle a self-hosted gitlab instance with subgroups, a combination that wasn't supported before.