### PR TITLE
support non-gitlab hosted urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,7 @@ module.exports = function (string) {
   // normalize git@ and https:git@ urls
   string = string.replace(/^git@/, 'https://')
   string = string.replace(/^https:git@/, 'https://')
-  string = string.replace('.com:', '.com/')
-
+  string = string.replace(/\.([A-Za-z]+)\:/, '.$1/');
   if (!~string.indexOf('://')) {
     return false
   }
@@ -38,7 +37,8 @@ module.exports = function (string) {
   if (m) return m.slice(1, 4)
 
   // https://docs.gitlab.com/ce/user/group/subgroups/
-  if (~url.host.indexOf('gitlab')) {
+  // https://git.company.com/ce/user/group/subgroups/
+  if (~url.host.indexOf('git')) {
     var m = /^\/((?:[\w-.]+\/)+)([\w-.]+)$/.exec(path)
     if (m) {
       m = m.slice(1, 3);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function (string) {
   // normalize git@ and https:git@ urls
   string = string.replace(/^git@/, 'https://')
   string = string.replace(/^https:git@/, 'https://')
-  string = string.replace(/\.([A-Za-z]+)\:/, '.$1/');
+  string = string.replace(/:([^/])/, '/$1');
   if (!~string.indexOf('://')) {
     return false
   }
@@ -37,15 +37,12 @@ module.exports = function (string) {
   if (m) return m.slice(1, 4)
 
   // https://docs.gitlab.com/ce/user/group/subgroups/
-  // https://git.company.com/ce/user/group/subgroups/
-  if (~url.host.indexOf('git')) {
-    var m = /^\/((?:[\w-.]+\/)+)([\w-.]+)$/.exec(path)
-    if (m) {
-      m = m.slice(1, 3);
-      // remove slash at the end
-      m[0] = m[0].slice(0, -1);
-      return m.concat((url.hash || '').slice(1));
-    }
+  var m = /^\/((?:[\w-.]+\/)+)([\w-.]+)$/.exec(path)
+  if (m) {
+    m = m.slice(1, 3);
+    // remove slash at the end
+    m[0] = m[0].slice(0, -1);
+    return m.concat((url.hash || '').slice(1));
   }
 
   return false

--- a/test.js
+++ b/test.js
@@ -92,14 +92,8 @@ describe('gitlab urls', function () {
     assert.deepEqual(['user', 'test1', ''], parsed)
   })
 
-  it('parses https non-itlab url', function () {
-    var url = 'https://git.mycompany.com/user/test1.git'
-    var parsed = parse(url)
-    assert.deepEqual(['user', 'test1', ''], parsed)
-  })
-
-  it('parses https non-itlab url', function () {
-    var url = 'https://git.mycompany.local/user/test1.git'
+  it('parses https non-gitlab url', function () {
+    var url = 'https://mycompany.local/user/test1.git'
     var parsed = parse(url)
     assert.deepEqual(['user', 'test1', ''], parsed)
   })

--- a/test.js
+++ b/test.js
@@ -12,6 +12,8 @@ describe('versionless', function () {
     'https://github.com/repos/component/emitter/zipball',
     'https://codeload.github.com/component/emitter/legacy.zip',
     'https://codeload.github.com/component/emitter/legacy.tar.gz',
+    'https://git.github.local/component/emitter/legacy.tar.gz',
+    'https://git.github.com/component/emitter/legacy.tar.gz'
   ].forEach(function (url) {
     it(url, function () {
       assert.deepEqual(['component', 'emitter', ''], parse(url))
@@ -43,6 +45,8 @@ describe('versioned', function () {
     'https://codeload.github.com/component/emitter/legacy.zip/1',
     'https://codeload.github.com/component/emitter/legacy.tar.gz/1',
     'https://github.com/component/emitter/archive/1.tar.gz',
+    'https://git.company.local/component/emitter/archive/1.tar.gz',
+    'https://git.company.com/component/emitter/archive/1.tar.gz',
   ].forEach(function (url) {
     it(url, function () {
       assert.deepEqual(['component', 'emitter', '1'], parse(url))
@@ -56,6 +60,8 @@ describe('dotted user', function () {
     'https://github.com/my.component/emitter',
     'https://github.com/repos/my.component/emitter/tarball',
     'https://codeload.github.com/my.component/emitter/legacy.zip',
+    'https://git.company.local/my.component/emitter/legacy.zip',
+    'https://git.company.com/my.component/emitter/legacy.zip',
   ].forEach(function (url) {
     it(url, function () {
       assert.deepEqual(['my.component', 'emitter', ''], parse(url))
@@ -116,10 +122,16 @@ describe('gitlab urls', function () {
     assert.deepEqual(['user/subgroup1/subgroup2/subgroup3', 'test1', ''], parsed)
   })
 
-  it('cannot parse subgroups in non-gitlab URLs', function () {
-    var url = 'git@stash.local:user/subgroup1/subgroup2/subgroup3/test1.git'
+  it('parses git hosted non-gitlab url with subgroups', function () {
+    var url = 'git@git.team.com:user/subgroup1/subgroup2/subgroup3/test1.git'
     var parsed = parse(url)
-    assert.equal(false, parsed)
+    assert.deepEqual(['user/subgroup1/subgroup2/subgroup3', 'test1', ''], parsed)
+  })
+
+  it('parses subgroups in non-gitlab URLs', function () {
+    var url = 'git@gitlab.local:user/subgroup1/subgroup2/subgroup3/test1.git'
+    var parsed = parse(url)
+    assert.deepEqual(['user/subgroup1/subgroup2/subgroup3', 'test1', ''], parsed)
   })
 })
 
@@ -132,6 +144,12 @@ describe('git @ syntax', function () {
 
   it('works for https:git url', function () {
     var url = 'https:git@github.com:bahmutov/lazy-ass.git'
+    var parsed = parse(url)
+    assert.deepEqual(['bahmutov', 'lazy-ass', ''], parsed)
+  });
+
+  it('works for https:git custom url', function () {
+    var url = 'https:git@git.company.local:bahmutov/lazy-ass.git'
     var parsed = parse(url)
     assert.deepEqual(['bahmutov', 'lazy-ass', ''], parsed)
   });

--- a/test.js
+++ b/test.js
@@ -92,6 +92,18 @@ describe('gitlab urls', function () {
     assert.deepEqual(['user', 'test1', ''], parsed)
   })
 
+  it('parses https non-itlab url', function () {
+    var url = 'https://git.mycompany.com/user/test1.git'
+    var parsed = parse(url)
+    assert.deepEqual(['user', 'test1', ''], parsed)
+  })
+
+  it('parses https non-itlab url', function () {
+    var url = 'https://git.mycompany.local/user/test1.git'
+    var parsed = parse(url)
+    assert.deepEqual(['user', 'test1', ''], parsed)
+  })
+
   it('parses git gitlab url', function () {
     var url = 'git@gitlab.com:user/test1.git'
     var parsed = parse(url)
@@ -129,7 +141,7 @@ describe('gitlab urls', function () {
   })
 
   it('parses subgroups in non-gitlab URLs', function () {
-    var url = 'git@gitlab.local:user/subgroup1/subgroup2/subgroup3/test1.git'
+    var url = 'git@git.team.local:user/subgroup1/subgroup2/subgroup3/test1.git'
     var parsed = parse(url)
     assert.deepEqual(['user/subgroup1/subgroup2/subgroup3', 'test1', ''], parsed)
   })


### PR DESCRIPTION
Fixing https://github.com/repo-utils/parse-github-repo-url/issues/5