### PR TITLE
fix: add support for url with port

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,11 @@ module.exports = function (string) {
 
   string = string.replace('//www.', '//')
   // normalize git@ and https:git@ urls
-  string = string.replace(/^git@/, 'https://')
-  string = string.replace(/^https:git@/, 'https://')
-  string = string.replace('.com:', '.com/')
+  if (~string.indexOf('git@') || ~string.indexOf('https:git@')) {
+    string = string.replace(/^git@/, 'https://')
+    string = string.replace(/^https:git@/, 'https://')
+    string = string.replace('.com:', '.com/')
+  }
 
   if (!~string.indexOf('://')) {
     return false


### PR DESCRIPTION
for example:

http://gitlab.com:10080/user/git-demo,  return '[ '10080/user', 'git-demo' ]' before fix, and return '[ 'user', 'git-demo' ]' now.
